### PR TITLE
Remove 0 as a type for to from

### DIFF
--- a/types.js
+++ b/types.js
@@ -131,8 +131,8 @@ export type STOPurchase = {|
 
 export type Investor = {|
   address: Address,
-  from: Date | 0,
-  to: Date | 0,
+  from: Date,
+  to: Date,
   added?: Date,
   addedBy?: Address,
 |}


### PR DESCRIPTION
I previously asked for these to be added. I have now figured out now to work with the type strictly only as Dates, so we don't need the 0's anymore